### PR TITLE
A couple fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,8 @@
 <body>
   <a-scene>
     <a-assets>
-      <a-mixin id="controller" super-hands controller-loaded sphere-collider="objects: .cube, .sphere" teleport-controls></a-mixin>
-      <a-mixin id="controller-loaded" static-body="shape: sphere; sphereRadius: 0.01;"></a-mixin>
+      <a-mixin id="controller" super-hands sphere-collider="objects: .cube, .sphere" teleport-controls
+               static-body="shape: sphere; sphereRadius: 0.01;"></a-mixin>
       <a-mixin id="cube" geometry="primitive: box; width: 0.5; height: 0.5; depth: 0.5" hoverable grabbable stretchable drag-droppable dynamic-body></a-mixin>
       <a-mixin id="cube-hovered" material="opacity: 0.7; transparent: true"></a-mixin>
       <a-mixin id="cube-dragover" material="wireframe: true;"></a-mixin>

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 require('aframe');
-require('aframe-extras');
+require('aframe-extras').registerAll();
 require('super-hands');
 require('aframe-teleport-controls');
-require('aframe-physics-components');
+// require('aframe-physics-components');
 var physics = require('aframe-physics-system');
 physics.registerAll();


### PR DESCRIPTION
I found two issues that were preventing the grabbing from working, and it works for me after these changes

1. `aframe-extras` components weren't getting registered, so `sphere-collider` wasn't available
2. The controllers weren't getting their physics bodies activated 

The `controller-loaded` component was a hack I employed when the A-Frame v0.4.0 first came out and was conflicting with the physics system version at the time, but I see now it works fine without it, so I need to update my example. 

I also commented out the `aframe-physics-component` load - it didn't seem to be contributing anything to the scene and didn't install for me since it's not listed in the package description. 